### PR TITLE
feat: support non protected GPG keys

### DIFF
--- a/aptly_ctl/Config.py
+++ b/aptly_ctl/Config.py
@@ -36,7 +36,7 @@ class SigningConfig:
                     "Config must contain 'gpgkey'. Do not rely on default key."
                 )
             if (passphrase and passphrase_file) or (
-                not passphrase and not passphrase_file
+                passphrase is None and passphrase_file is None
             ):
                 raise AptlyCtlError(
                     "Config must contain either 'passphrase' or 'passphrase_file'."

--- a/tests/test_Config.py
+++ b/tests/test_Config.py
@@ -67,6 +67,22 @@ class TestConfig:
                         "passphrase": "jessie"
                     }
                 }
+            },
+            {
+                "name": "with_empty_passphrase",
+                "url": "http://somehost:8090/api",
+                "signing": {
+                    "gpgkey": "foobar",
+                    "passphrase": ""
+                },
+            },
+            {
+                "name": "with_empty_passphrase_file",
+                "url": "http://somehost:8090/api",
+                "signing": {
+                    "gpgkey": "foobar",
+                    "passphrase": ""
+                },
             }
         ]
     }


### PR DESCRIPTION
This allows `signing.passphrase` and `signing.passphrase_file` to be
empty.